### PR TITLE
Remove redundant $or from match stage

### DIFF
--- a/m121/final-exam/question7.js
+++ b/m121/final-exam/question7.js
@@ -3,15 +3,11 @@
 var pipeline = [
     {
         $match: {
-            $or: [
-                {
-                    $and: [
-                        { src_airport: 'JFK' }, { dst_airport: 'LHR' }
-                    ],
-                    $and: [
-                        { src_airport: 'LHR' }, { dst_airport: 'JFK' }
-                    ]
-                }
+            $and: [
+                { src_airport: 'JFK' }, { dst_airport: 'LHR' }
+            ],
+            $and: [
+                { src_airport: 'LHR' }, { dst_airport: 'JFK' }
             ]
         }
     },


### PR DESCRIPTION
The $or array only had one object in it thus it was doing nothing but returning exactly the same object without doing anything. I have test the query by removing or and gives the exact same results.